### PR TITLE
fix to build on latest Arduino 1.8.1 and lastest avr 1.6.16

### DIFF
--- a/libraries/ChibiOS_AVR/src/utility/chthreads.c
+++ b/libraries/ChibiOS_AVR/src/utility/chthreads.c
@@ -394,6 +394,7 @@ void chThdYield(void) {
  *
  * @api
  */
+void chThdExit(msg_t msg) __attribute__((used));  //<<<< ADD THIS LINE
 void chThdExit(msg_t msg) {
 
   chSysLock();


### PR DESCRIPTION
From fat16lib@sbcglobal.net :
Go to libraries/ChibiOS_AVR/src/utility/chthreads.c and add this as a
work around at line 397.

void chThdExit(msg_t msg) __attribute__((used));  //<<<< ADD THIS LINE
void chThdExit(msg_t msg) {

chSysLock();
chThdExitS(msg);
/* The thread never returns here.*/
}